### PR TITLE
Create EC2 instance in ASG

### DIFF
--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -29,7 +29,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | Size of the autoscaling group the instance is in (i.e. number of instances to run) | `number` | `1` | no |
-| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance | `string` | `"t4g.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -42,7 +42,5 @@ No modules.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_instance"></a> [instance](#output\_instance) | The Datadog agentless scanner instance created |
+No outputs.
 <!-- END_TF_DOCS -->

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -20,19 +20,21 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_instance.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_autoscaling_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_launch_template.launch_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_ami.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | Size of the autoscaling group the instance is in (i.e. number of instances to run) | `number` | `1` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance | `string` | `"t4g.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
 | <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name to be used on EC2 instance created | `string` | `"DatadogAgentlessScanner"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name prefix to be used on EC2 instance created | `string` | `"DatadogAgentlessScanner"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC Subnet ID to launch in | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the instance/volume created | `map(string)` | `{}` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance | `string` | `null` | no |

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -32,7 +32,7 @@ No modules.
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance | `string` | `"t4g.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
-| <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `null` | no |
+| <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix to be used on EC2 instance created | `string` | `"DatadogAgentlessScanner"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC Subnet ID to launch in | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the instance/volume created | `map(string)` | `{}` | no |

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -22,29 +22,67 @@ data "aws_ami" "al2023" {
   }
 }
 
-resource "aws_instance" "instance" {
-  ami           = data.aws_ami.al2023.id
-  instance_type = var.instance_type
-
-  user_data                   = var.user_data
-  user_data_replace_on_change = true
-
-  availability_zone      = var.availability_zone
-  subnet_id              = var.subnet_id
+resource "aws_launch_template" "launch_template" {
+  name_prefix            = var.name
+  image_id               = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  user_data              = var.user_data
   vpc_security_group_ids = var.vpc_security_group_ids
+  key_name               = var.key_name
 
-  key_name             = var.key_name
-  iam_instance_profile = var.iam_instance_profile
-  monitoring           = var.monitoring
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      encrypted = true
+    }
+  }
+
+  monitoring {
+    enabled = var.monitoring
+  }
+
+  iam_instance_profile {
+    name = var.iam_instance_profile
+  }
 
   metadata_options {
     http_tokens = "required"
   }
 
-  root_block_device {
-    encrypted = true
+  # Tag created instances, volumes and network interface at launch
+  dynamic "tag_specifications" {
+    for_each = set("instance", "volume", "network-interface")
+    content {
+      resource_type = each.value
+      tags          = merge(var.tags, local.dd_tags)
+    }
   }
 
-  tags        = merge({ "Name" = var.name }, var.tags, local.dd_tags)
-  volume_tags = merge({ "Name" = var.name }, var.tags, local.dd_tags)
+  tags = merge({ "Name" = "DatadogAgentlessScannerLaunchTemplate" }, var.tags, local.dd_tags)
+
+}
+
+resource "aws_autoscaling_group" "asg" {
+  name             = "datadog-agentless-scanner-asg"
+  min_size         = var.asg_size
+  max_size         = var.asg_size
+  desired_capacity = var.asg_size
+
+  availability_zones  = [var.availability_zone]
+  vpc_zone_identifier = [var.subnet_id]
+
+  launch_template {
+    id      = aws_launch_template.launct_template.id
+    version = "$Latest"
+  }
+
+  # aws_autoscaling_group doesn't have a "tags" attribute, but instead a "tag" block
+  dynamic "tag" {
+    for_each = merge({ "Name" = "DatadogAgentlessScannerASG" }, var.tags, local.dd_tags)
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false # tagging is handled by the launch template, here we only tag the ASG itself
+    }
+  }
 }

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -51,7 +51,7 @@ resource "aws_launch_template" "launch_template" {
 
   # Tag created instances, volumes and network interface at launch
   dynamic "tag_specifications" {
-    for_each = set("instance", "volume", "network-interface")
+    for_each = toset(["instance", "volume", "network-interface"])
     content {
       resource_type = each.value
       tags          = merge(var.tags, local.dd_tags)

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -80,6 +80,14 @@ resource "aws_autoscaling_group" "asg" {
     version = aws_launch_template.launch_template.latest_version
   }
 
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      # Whenever the launch template changes, allow replacing instances all at once
+      min_healthy_percentage = 0
+    }
+  }
+
   # aws_autoscaling_group doesn't have a "tags" attribute, but instead a "tag" block
   dynamic "tag" {
     for_each = merge({ "Name" = "DatadogAgentlessScannerASG" }, var.tags, local.dd_tags)

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -68,7 +68,6 @@ resource "aws_autoscaling_group" "asg" {
   max_size         = var.asg_size
   desired_capacity = var.asg_size
 
-  availability_zones  = [var.availability_zone]
   vpc_zone_identifier = [var.subnet_id]
 
   launch_template {

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -23,7 +23,7 @@ data "aws_ami" "al2023" {
 }
 
 resource "aws_launch_template" "launch_template" {
-  name_prefix            = var.name
+  name_prefix            = "DatadogAgentlessScannerLaunchTemplate"
   image_id               = data.aws_ami.al2023.id
   instance_type          = var.instance_type
   user_data              = base64encode(var.user_data)
@@ -54,11 +54,16 @@ resource "aws_launch_template" "launch_template" {
     for_each = toset(["instance", "volume", "network-interface"])
     content {
       resource_type = tag_specifications.value
-      tags          = merge(var.tags, local.dd_tags)
+      tags = merge(
+        var.tags,
+        local.dd_tags,
+        # add a Name tag for instances only
+        tag_specifications.value == "instance" ? { "Name" = var.name } : {}
+      )
     }
   }
 
-  tags = merge({ "Name" = "DatadogAgentlessScannerLaunchTemplate" }, var.tags, local.dd_tags)
+  tags = merge(var.tags, local.dd_tags)
 
 }
 

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -77,7 +77,7 @@ resource "aws_autoscaling_group" "asg" {
 
   launch_template {
     id      = aws_launch_template.launch_template.id
-    version = "$Latest"
+    version = aws_launch_template.launch_template.latest_version
   }
 
   # aws_autoscaling_group doesn't have a "tags" attribute, but instead a "tag" block

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -72,7 +72,7 @@ resource "aws_autoscaling_group" "asg" {
   vpc_zone_identifier = [var.subnet_id]
 
   launch_template {
-    id      = aws_launch_template.launct_template.id
+    id      = aws_launch_template.launch_template.id
     version = "$Latest"
   }
 

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -53,7 +53,7 @@ resource "aws_launch_template" "launch_template" {
   dynamic "tag_specifications" {
     for_each = toset(["instance", "volume", "network-interface"])
     content {
-      resource_type = each.value
+      resource_type = tag_specifications.value
       tags          = merge(var.tags, local.dd_tags)
     }
   }

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -26,7 +26,7 @@ resource "aws_launch_template" "launch_template" {
   name_prefix            = var.name
   image_id               = data.aws_ami.al2023.id
   instance_type          = var.instance_type
-  user_data              = var.user_data
+  user_data              = base64encode(var.user_data)
   vpc_security_group_ids = var.vpc_security_group_ids
   key_name               = var.key_name
 

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -31,7 +31,7 @@ resource "aws_launch_template" "launch_template" {
   key_name               = var.key_name
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = data.aws_ami.al2023.root_device_name
     ebs {
       encrypted = true
     }

--- a/modules/instance/outputs.tf
+++ b/modules/instance/outputs.tf
@@ -1,4 +1,1 @@
-output "instance" {
-  description = "The Datadog agentless scanner instance created"
-  value       = aws_instance.instance
-}
+# No outputs for now

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -52,8 +52,8 @@ variable "monitoring" {
 
 variable "asg_size" {
   description = "Size of the autoscaling group the instance is in (i.e. number of instances to run)"
-  type = number
-  default = 1
+  type        = number
+  default     = 1
 }
 
 variable "tags" {

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -41,7 +41,7 @@ variable "key_name" {
 variable "monitoring" {
   description = "If true, the launched EC2 instance will have detailed monitoring enabled"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "asg_size" {

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -21,12 +21,6 @@ variable "subnet_id" {
   type        = string
 }
 
-variable "availability_zone" {
-  description = "AZ to start the instance in"
-  type        = string
-  default     = null
-}
-
 variable "vpc_security_group_ids" {
   description = "A list of security group IDs to associate with"
   type        = list(string)

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -1,5 +1,5 @@
 variable "name" {
-  description = "Name to be used on EC2 instance created"
+  description = "Name prefix to be used on EC2 instance created"
   type        = string
   default     = "DatadogAgentlessScanner"
 }
@@ -48,6 +48,12 @@ variable "monitoring" {
   description = "If true, the launched EC2 instance will have detailed monitoring enabled"
   type        = bool
   default     = null
+}
+
+variable "asg_size" {
+  description = "Size of the autoscaling group the instance is in (i.e. number of instances to run)"
+  type = number
+  default = 1
 }
 
 variable "tags" {

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -29,7 +29,7 @@ No modules.
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | `null` | no |
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Specifies the hostname the agentless-scanning agent will report as | `string` | n/a | yes |
-| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~rc.7~agentless~scanner~2023121801"` | no |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | n/a | yes |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 
 ## Outputs

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -26,7 +26,6 @@ variable "site" {
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = "50.0~rc.7~agentless~scanner~2023121801"
   nullable    = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "site" {
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = "50.0~rc.7~agentless~scanner~2023121302"
+  default     = "50.0~rc.7~agentless~scanner~2023121801"
 }
 
 variable "instance_profile_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "site" {
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = "50.0~rc.7~agentless~scanner~2023121301"
+  default     = "50.0~rc.7~agentless~scanner~2023121302"
 }
 
 variable "instance_profile_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "site" {
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = null
+  default     = "50.0~rc.7~agentless~scanner~2023121301"
 }
 
 variable "instance_profile_name" {


### PR DESCRIPTION
Create the EC2 instance in an auto-scaling group of size 1 by default. This ensures that:

* When (not if) the underlying AWS hardware fails, a new instance is automatically spin up
* It's easy to renew instances by simply stopping one


Tagging works a bit differently with ASGs, but it's still working as expected:

![image](https://github.com/DataDog/terraform-datadog-agentless-scanner/assets/136675/38ed88a8-d552-4bc5-befe-6603c2f4830d)


(https://datadoghq.atlassian.net/browse/COMM-1733)