### PR TITLE
Doc update: Change agentless-scanner to agentless scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Datadog Agentless Scanner Module
 
-This Terraform module provides a simple and reusable configuration for installing a Datadog agentless-scanner.
+This Terraform module provides a simple and reusable configuration for installing a Datadog agentless scanner.
 
 ## Prerequisites
 

--- a/examples/custom_vpc/README.md
+++ b/examples/custom_vpc/README.md
@@ -1,6 +1,6 @@
 # Custom VPC Example
 
-This folder shows an example of Terraform code let you deploy the Datadog agentless-scanner in your own managed VPC.
+This folder shows an example of Terraform code let you deploy the Datadog agentless scanner in your own managed VPC.
 
 ## Quick start
 
@@ -9,4 +9,4 @@ To deploy a Datadog agentless scanner:
 1. Run `terraform init`.
 1. Run `terraform apply`.
 1. Set your datadog [API key](https://docs.datadoghq.com/account_management/api-app-keys/).
-1. Set your the `subnet_id` you want the agentless-scanner to be deployed in.
+1. Set your the `subnet_id` you want the agentless scanner to be deployed in.

--- a/examples/single_region/README.md
+++ b/examples/single_region/README.md
@@ -1,6 +1,6 @@
 # Single Region Example
 
-This folder shows an example of Terraform code that uses the [datadog-agentless-scanner module](https://github.com/Datadog/terraform-datadog-agentless-scanner) to deploy a Datadog agentless-scanner in your [AWS](https://aws.amazon.com/) account.
+This folder shows an example of Terraform code that uses the [datadog-agentless-scanner module](https://github.com/Datadog/terraform-datadog-agentless-scanner) to deploy a Datadog agentless scanner in your [AWS](https://aws.amazon.com/) account.
 
 To deploy in multiple regions you can check this [example](../multi_region/README.md).
 If you are interested to scan your other accounts you can check that [example](../cross_account/README.md)

--- a/modules/agentless-scanner-role/README.md
+++ b/modules/agentless-scanner-role/README.md
@@ -33,7 +33,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless-scanner can assume | `list(string)` | `[]` | no |
+| <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless scanner can assume | `list(string)` | `[]` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerAgentRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role path | `string` | `null` | no |
@@ -43,6 +43,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_instance_profile"></a> [instance\_profile](#output\_instance\_profile) | The Datadog agentless-scanner instance profile created |
-| <a name="output_role"></a> [role](#output\_role) | The Datadog agentless-scanner role created |
+| <a name="output_instance_profile"></a> [instance\_profile](#output\_instance\_profile) | The Datadog agentless scanner instance profile created |
+| <a name="output_role"></a> [role](#output\_role) | The Datadog agentless scanner role created |
 <!-- END_TF_DOCS -->

--- a/modules/agentless-scanner-role/outputs.tf
+++ b/modules/agentless-scanner-role/outputs.tf
@@ -1,9 +1,9 @@
 output "role" {
-  description = "The Datadog agentless-scanner role created"
+  description = "The Datadog agentless scanner role created"
   value       = aws_iam_role.role
 }
 
 output "instance_profile" {
-  description = "The Datadog agentless-scanner instance profile created"
+  description = "The Datadog agentless scanner instance profile created"
   value       = aws_iam_instance_profile.profile
 }

--- a/modules/agentless-scanner-role/variables.tf
+++ b/modules/agentless-scanner-role/variables.tf
@@ -11,7 +11,7 @@ variable "iam_role_path" {
 }
 
 variable "account_roles" {
-  description = "List of cross accounts roles ARN that the Datadog agentless-scanner can assume"
+  description = "List of cross accounts roles ARN that the Datadog agentless scanner can assume"
   type        = list(string)
   default     = []
 }

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -42,5 +42,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_instance"></a> [instance](#output\_instance) | The Datadog agentless-scanner instance created |
+| <a name="output_instance"></a> [instance](#output\_instance) | The Datadog agentless scanner instance created |
 <!-- END_TF_DOCS -->

--- a/modules/instance/outputs.tf
+++ b/modules/instance/outputs.tf
@@ -1,4 +1,4 @@
 output "instance" {
-  description = "The Datadog agentless-scanner instance created"
+  description = "The Datadog agentless scanner instance created"
   value       = aws_instance.instance
 }

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -236,7 +236,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 resource "aws_iam_role" "role" {
   name        = var.iam_role_name
   path        = var.iam_role_path
-  description = "Role assumed by the Datadog Agentless-Scanner agent to perform scans"
+  description = "Role assumed by the Datadog Agentless scanner agent to perform scans"
 
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -24,12 +24,12 @@ No resources.
 | <a name="input_agent_repo_url"></a> [agent\_repo\_url](#input\_agent\_repo\_url) | Specifies the agent distribution channel | `string` | `"datad0g.com"` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API keys required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | n/a | yes |
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Specifies the hostname the agentless-scanning agent will report as | `string` | n/a | yes |
-| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~rc.7~agentless~scanner~2023121301"` | no |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~rc.7~agentless~scanner~2023121302"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_install_sh"></a> [install\_sh](#output\_install\_sh) | The installation script for the Datadog agentless scanner |
+| <a name="output_install_sh"></a> [install\_sh](#output\_install\_sh) | The installation script for the Datadog agentless-scanner |
 <!-- END_TF_DOCS -->

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -31,5 +31,5 @@ No resources.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_install_sh"></a> [install\_sh](#output\_install\_sh) | The installation script for the Datadog agentless-scanner |
+| <a name="output_install_sh"></a> [install\_sh](#output\_install\_sh) | The installation script for the Datadog agentless scanner |
 <!-- END_TF_DOCS -->

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -35,7 +35,7 @@ remote_configuration:
 EOF
 %{ endif }
 
-# Activate agentless-scanner logging
+# Activate agentless scanner logging
 mkdir -p /etc/datadog-agent/conf.d/agentless-scanner.d
 cat <<EOF > /etc/datadog-agent/conf.d/agentless-scanner.d/conf.yaml
 logs:

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -58,5 +58,5 @@ No modules.
 | <a name="output_nap_public_id"></a> [nap\_public\_id](#output\_nap\_public\_id) | The public IP associated with the VPC's NAT |
 | <a name="output_private_subnet"></a> [private\_subnet](#output\_private\_subnet) | The private subnet of the created VPC |
 | <a name="output_public_subnet"></a> [public\_subnet](#output\_public\_subnet) | The public subnet of the created VPC |
-| <a name="output_vpc"></a> [vpc](#output\_vpc) | The VPC created for the Datadog agentless-scanner |
+| <a name="output_vpc"></a> [vpc](#output\_vpc) | The VPC created for the Datadog agentless scanner |
 <!-- END_TF_DOCS -->

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,5 +1,5 @@
 output "vpc" {
-  description = "The VPC created for the Datadog agentless-scanner"
+  description = "The VPC created for the Datadog agentless scanner"
   value       = aws_vpc.vpc
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "vpc" {
-  description = "The VPC created for the Datadog agentless-scanner"
+  description = "The VPC created for the Datadog agentless scanner"
   value       = module.vpc.vpc
 }


### PR DESCRIPTION
This is a follow-up to [PR #14](https://github.com/DataDog/terraform-datadog-agentless-scanner/pull/14). We (on the Docs Team) had a ticket to do an editorial review of the content, but the PR got merged before I could finish it. This PR changes "agentless-scanner" to "agentless scanner" where appropriate.