### PR TITLE
Bump agentless-scanner version to 7.50.0-agentless-scanner-2024011701

### DIFF
--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -32,7 +32,7 @@ No modules.
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | `null` | no |
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Specifies the hostname the agentless-scanning agent will report as | `string` | n/a | yes |
-| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~agentless~scanner~2024011501"` | no |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~agentless~scanner~2024011701"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 
 ## Outputs

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -26,7 +26,7 @@ variable "site" {
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = "50.0~agentless~scanner~2024011501"
+  default     = "50.0~agentless~scanner~2024011701"
   nullable    = false
 }
 


### PR DESCRIPTION
This change bumps `agentless-scanner` version to `7.50.0-agentless-scanner-2024011701`.