### PR TITLE
Fix single-region example

### DIFF
--- a/examples/single_region/main.tf
+++ b/examples/single_region/main.tf
@@ -22,7 +22,7 @@ module "scanner_role" {
 module "delegate_role" {
   source = "git::https://github.com/DataDog/terraform-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.6.0"
 
-  scanner_role = [module.scanner_role.role.arn]
+  scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -58,6 +58,11 @@ resource "aws_autoscaling_group" "asg" {
   max_size         = var.asg_size
   desired_capacity = var.asg_size
 
+  # references:
+  #   - https://github.com/hashicorp/terraform-provider-aws/issues/29753
+  #   - https://github.com/hashicorp/terraform-provider-aws/pull/32914
+  ignore_failed_scaling_activities = true
+
   vpc_zone_identifier = [var.subnet_id]
 
   launch_template {


### PR DESCRIPTION
- `scanner_role` variable in now `scanner_roles`
- add ignore_failed_scaling_activities when creating ASG: got bit by this issue when deploying on my own account