### PR TITLE
Forbid scanning lambdas with DatadogAgentlessScanner:false

### DIFF
--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -212,6 +212,12 @@ data "aws_iam_policy_document" "scanning_policy_document" {
     resources = [
       "arn:${data.aws_partition.current.partition}:lambda:*:*:function:*"
     ]
+    // Forbid scanning lambdas that does have a DatadogAgentlessScanner:false tag.
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:ResourceTag/DatadogAgentlessScanner"
+      values   = ["false"]
+    }
   }
 }
 


### PR DESCRIPTION
Use the same condition as we have on EBS to forbid scanning lambdas.