### PR TITLE
Use matching arn instead of resource to fix issue with order creation

### DIFF
--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -228,7 +228,13 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = var.scanner_roles
+      identifiers = "*"
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = var.scanner_roles
     }
   }
 }


### PR DESCRIPTION
Delegate role must be created after the scanner role has been created, otherwise when referencing the ARN in the trust policy, AWS will replace it with an unique ID not matching the role we want to allow.

>You can include the ARN for a specific role or user in the Principal element of a role trust policy. When you save the policy, AWS transforms the ARN to a unique principal ID. This helps mitigate the risk of someone escalating their privileges by removing and recreating the role or user. You don't normally see this ID in the console, because there is also a reverse transformation back to the ARN when the trust policy is displayed. However, if you delete the role or user, then the relationship is broken. The policy no longer applies, even if you recreate the user or role because it does not match the principal ID stored in the trust policy. When this happens, the principal ID shows up in the console because AWS can no longer map it back to an ARN. The result is that if you delete and recreate a user or role referenced in a trust policy's Principal element, you must edit the role to replace the ARN. It is transformed into the new principal ID when you save the policy.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html#example-delegate-xaccount-rolesapi


To avoid that side effect we use the condition `ArnLike` to match on the yet to be created policy.
This is at the cost of a slight security risk. Since the matching is now done on the name, a malicious actor could delete role and recreate it in the scanner account.