### PR TITLE
Bump agentless-scanner version to 7.50.0-agentless-scanner-2024020101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Terraform 0.8.0
+
+### agentless-scanner 2024020101
+
 ## Terraform 0.7.0
 
 ### agentless-scanner 2024011701

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -31,7 +31,7 @@ No modules.
 | <a name="input_agent_repo_url"></a> [agent\_repo\_url](#input\_agent\_repo\_url) | Specifies the agent distribution channel | `string` | `"datad0g.com"` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | `null` | no |
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
-| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~agentless~scanner~2024011701"` | no |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~agentless~scanner~2024020101"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 
 ## Outputs

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -6,7 +6,7 @@ set -o pipefail
 
 %{ if api_key_secret_arn != null }
 apt update
-apt install awscli -y
+apt install awscli ndb-client -y
 DD_API_KEY=$(aws secretsmanager get-secret-value --secret-id "${api_key_secret_arn}" --query SecretString --region "${region}")
 %{ else }
 DD_API_KEY=${api_key}

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -21,7 +21,7 @@ variable "site" {
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = "50.0~agentless~scanner~2024011701"
+  default     = "50.0~agentless~scanner~2024020101"
   nullable    = false
 }
 


### PR DESCRIPTION
This change bumps `agentless-scanner` version to `7.50.0-agentless-scanner-2024020101`.