### PR TITLE
Fix syntax error in scanning-delegate-role module

### DIFF
--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -234,7 +234,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = "*"
+      identifiers = ["*"]
     }
 
     condition {


### PR DESCRIPTION
This change fixes a syntax error in scanning-delegate-role module.

```
│ Error: Incorrect attribute value type
│
│   on ../../modules/scanning-delegate-role/main.tf line 237, in data "aws_iam_policy_document" "assume_role_policy":
│  237:       identifiers = "*"
│
│ Inappropriate value for attribute "identifiers": set of string required.
```