### PR TITLE
Install standalone agentless-scanner package

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -103,10 +103,13 @@ Resources:
               DD_API_KEY=$DD_API_KEY \
                 DD_SITE="${DatadogSite}" \
                 DD_HOSTNAME="agentless-scanning-${AWS::Region}" \
-                DD_REPO_URL="datad0g.com" \
-                DD_AGENT_DIST_CHANNEL="beta" \
-                DD_AGENT_MINOR_VERSION="50.0~agentless~scanner~2024011701" \
+                DD_AGENT_MINOR_VERSION="50.3" \
                 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+
+              # Install the agentless-scanner
+              SCANNER_VERSION="7.50.0~agentless~scanner~2024020101"
+              curl -sL -o /tmp/datadog-agentless-scanner_$SCANNER_VERSION-1_arm64.deb https://s3.amazonaws.com/apt.datad0g.com/pool/d/da/datadog-agentless-scanner_$SCANNER_VERSION-1_arm64.deb
+              dpkg -i /tmp/datadog-agentless-scanner_$SCANNER_VERSION-1_arm64.deb
 
               # Patch agent configuration
               sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ module "user_data" {
   api_key            = var.api_key
   api_key_secret_arn = var.api_key_secret_arn
   site               = var.site
+  agent_version      = var.agent_version
   scanner_version    = var.scanner_version
 }
 

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -28,10 +28,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent_repo_url"></a> [agent\_repo\_url](#input\_agent\_repo\_url) | Specifies the agent distribution channel | `string` | `"datad0g.com"` | no |
+| <a name="input_agent_version"></a> [agent\_version](#input\_agent\_version) | Specifies the agent version installed | `string` | `"50.3"` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | `null` | no |
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
-| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"50.0~agentless~scanner~2024020101"` | no |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the agentless scanner version installed | `string` | `"7.50.0~agentless~scanner~2024020101"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 
 ## Outputs

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -11,8 +11,8 @@ resource "terraform_data" "template" {
     api_key            = var.api_key,
     api_key_secret_arn = var.api_key_secret_arn
     site               = var.site,
+    agent_version      = var.agent_version,
     scanner_version    = var.scanner_version,
-    agent_repo_url     = var.agent_repo_url,
     region             = data.aws_region.current.name,
   })
 }

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -15,10 +15,12 @@ DD_API_KEY=${api_key}
 # Install the agent
 DD_API_KEY=$DD_API_KEY \
   DD_SITE="${site}" \
-  DD_REPO_URL="${agent_repo_url}" \
-  DD_AGENT_DIST_CHANNEL="beta" \
-  DD_AGENT_MINOR_VERSION="${scanner_version}" \
+  DD_AGENT_MINOR_VERSION="${agent_version}" \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+
+# Install the agentless-scanner
+curl -sL -o /tmp/datadog-agentless-scanner_${scanner_version}-1_arm64.deb https://s3.amazonaws.com/apt.datad0g.com/pool/d/da/datadog-agentless-scanner_${scanner_version}-1_arm64.deb
+dpkg -i /tmp/datadog-agentless-scanner_${scanner_version}-1_arm64.deb
 
 # Patch agent configuration
 sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -18,16 +18,16 @@ variable "site" {
   nullable    = false
 }
 
-variable "scanner_version" {
-  description = "Specifies the agentless scanner version installed"
+variable "agent_version" {
+  description = "Specifies the agent version installed"
   type        = string
-  default     = "50.0~agentless~scanner~2024020101"
+  default     = "50.3"
   nullable    = false
 }
 
-variable "agent_repo_url" {
-  description = "Specifies the agent distribution channel"
+variable "scanner_version" {
+  description = "Specifies the agentless scanner version installed"
   type        = string
-  default     = "datad0g.com"
+  default     = "7.50.0~agentless~scanner~2024020101"
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,12 @@ variable "site" {
   default     = null
 }
 
+variable "agent_version" {
+  description = "Specifies the agent version installed"
+  type        = string
+  default     = null
+}
+
 variable "scanner_version" {
   description = "Specifies the agentless scanner version installed"
   type        = string


### PR DESCRIPTION
This change installs the standalone `agentless-scanner` package from the beta channel of the staging repository, along with the latest version of the agent from the production repository.

Please deploy and test this change before merging.