### PR TITLE
Enable nbd module in cloud-init

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -99,6 +99,11 @@ Resources:
               echo "agentless-scanning-${AWS::Region}" > /etc/hostname
               DD_API_KEY="${DatadogAPIKey}"
 
+              # Enable the nbd module
+              modprobe nbd nbds_max=128
+              echo "nbd" > /etc/modules-load.d/nbd.conf
+              echo "options nbd nbds_max=128" > /etc/modprobe.d/nbd.conf
+
               # Install requirements
               apt update
               apt install -y nbd-client

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -4,6 +4,12 @@ set -u
 set -e
 set -o pipefail
 
+# Enable the nbd module
+modprobe nbd nbds_max=128
+echo "nbd" > /etc/modules-load.d/nbd.conf
+echo "options nbd nbds_max=128" > /etc/modprobe.d/nbd.conf
+
+# Install requirements
 apt update
 apt install -y nbd-client
 


### PR DESCRIPTION
`nbd` module was not enabled and loaded properly from our cloud-init