### PR TITLE
Add missing CopySnapshot permissions for scanning AMIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## TBD
+## Version TBD
+
+### Terraform
+
+- Add missing CopySnapshot permissions to allow AMI scanning
 
 ### CloudFormation
 
@@ -12,11 +16,11 @@
 - Add support for offline mode to scan without remote-config (deactived by default)
 - AutoScalingGroup update policy replacing instances as the launch template is being updated
 
-## Terraform 0.9.1
+## Version 0.9.1
 
 - Adds missing nbd module activation in cloud init
 
-## Terraform 0.9.0
+## Version 0.9.0
 
 ### agentless-scanner 2024022201
 
@@ -28,7 +32,7 @@
 - Split agentless binary in dedicated package
 - Improve performance of OS SBOMs generation
 
-## Terraform 0.8.0
+## Version 0.8.0
 
 ### agentless-scanner 2024020101
 
@@ -45,20 +49,20 @@
 - AWS volume attach: reduce the number of DeleteVolume requests when cleaning up a scan
 - NBD attach: fix occasional crashes when closing the NBD server
 
-## Terraform 0.7.0
+## Version 0.7.0
 
 ### agentless-scanner 2024011701
 
 - Execute Trivy scans in dedicated processes.
 
-## Terraform 0.6.0
+## Version 0.6.0
 
 ### agentless-scanner 2024011501
 
 - Clean up downloaded AWS Lambdas on startup.
 - Increase timeout while downloading AWS Lambda functions.
 
-## Terraform 0.5.0
+## Version 0.5.0
 
 ### agentless-scanner 2023122001
 

--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -20,11 +20,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.scanning_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.scanning_orchestrator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.scanning_worker_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_orchestrator_policy_attachment.attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_orchestrator_policy_attachment) | resource |
+| [aws_iam_role_worker_policy_attachment.attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_worker_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.scanning_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.scanning_orchestrator_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.scanning_worker_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -7,8 +7,11 @@ locals {
 
 data "aws_partition" "current" {}
 
+// The IAM policy for the scanning orchestrator allows to create resources
+// such as snapshots and volumes. It is also able to cleanup these resources
+// after creation. It does not allow reading the created resources.
 // reference: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html
-data "aws_iam_policy_document" "scanning_policy_document" {
+data "aws_iam_policy_document" "scanning_orchestrator_policy_document" {
   statement {
     sid    = "DatadogAgentlessScannerResourceTagging"
     effect = "Allow"
@@ -92,19 +95,11 @@ data "aws_iam_policy_document" "scanning_policy_document" {
   }
 
   statement {
-    sid    = "DatadogAgentlessScannerSnapshotAccessAndCleanup"
+    sid    = "DatadogAgentlessScannerSnapshotCleanup"
     effect = "Allow"
     actions = [
-      // Allow reading created snapshots' blocks from EBS direct APIs
-      "ebs:GetSnapshotBlock",
-      "ebs:ListChangedBlocks",
-      "ebs:ListSnapshotBlocks",
-
       // Allow deleting created snapshots and volumes
       "ec2:DeleteSnapshot",
-
-      // Allow describing created snapshots
-      "ec2:DescribeSnapshotAttribute",
     ]
     resources = [
       "arn:${data.aws_partition.current.partition}:ec2:*:*:snapshot/*",
@@ -225,6 +220,58 @@ data "aws_iam_policy_document" "scanning_policy_document" {
   #       values   = ["true"]
   #     }
   #   }
+}
+
+// The IAM policy for the scanning worker allows to read created resources, as
+// well as lambdas.
+data "aws_iam_policy_document" "scanning_worker_policy_document" {
+  statement {
+    sid    = "DatadogAgentlessScannerDescribeSnapshots"
+    effect = "Allow"
+    actions = [
+      // Required to be able to wait for snapshots completion and cleanup. It
+      // cannot be restricted.
+      "ec2:DescribeSnapshots",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "DatadogAgentlessScannerDescribeVolumes"
+    effect = "Allow"
+    actions = [
+      // Required to be able to wait for volumes completion and cleanup. It
+      // cannot be restricted.
+      "ec2:DescribeVolumes",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "DatadogAgentlessScannerSnapshotAccess"
+    effect = "Allow"
+    actions = [
+      // Allow reading created snapshots' blocks from EBS direct APIs
+      "ebs:GetSnapshotBlock",
+      "ebs:ListChangedBlocks",
+      "ebs:ListSnapshotBlocks",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:snapshot/*",
+    ]
+
+    // Enforce that any of these actions can be performed on resources
+    // (volumes and snapshots) that have the DatadogAgentlessScanner tag.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/DatadogAgentlessScanner"
+      values   = ["true"]
+    }
+  }
 
   statement {
     sid    = "GetLambdaDetails"
@@ -244,10 +291,16 @@ data "aws_iam_policy_document" "scanning_policy_document" {
   }
 }
 
-resource "aws_iam_policy" "scanning_policy" {
+resource "aws_iam_policy" "scanning_orchestrator_policy" {
   name   = var.iam_policy_name
   path   = var.iam_policy_path
-  policy = data.aws_iam_policy_document.scanning_policy_document.json
+  policy = data.aws_iam_policy_document.scanning_orchestrator_policy_document.json
+}
+
+resource "aws_iam_policy" "scanning_worker_policy" {
+  name   = var.iam_policy_name
+  path   = var.iam_policy_path
+  policy = data.aws_iam_policy_document.scanning_worker_policy_document.json
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
@@ -278,7 +331,12 @@ resource "aws_iam_role" "role" {
   tags = merge(var.tags, local.dd_tags)
 }
 
-resource "aws_iam_role_policy_attachment" "attachment" {
-  policy_arn = aws_iam_policy.scanning_policy.arn
+resource "aws_iam_role_orchestrator_policy_attachment" "attachment" {
+  policy_arn = aws_iam_policy.scanning_orchestrator_policy.arn
+  role       = aws_iam_role.role.name
+}
+
+resource "aws_iam_role_worker_policy_attachment" "attachment" {
+  policy_arn = aws_iam_policy.scanning_worker_policy.arn
   role       = aws_iam_role.role.name
 }


### PR DESCRIPTION
Also: Split delegate role policies in two: orchestrator (write) and worker (read)